### PR TITLE
Update Page.yml.orm

### DIFF
--- a/src/Resources/config/doctrine/Page.orm.yml
+++ b/src/Resources/config/doctrine/Page.orm.yml
@@ -15,7 +15,7 @@ BitBag\CmsPlugin\Entity\Page:
             type: boolean
     manyToMany:
         products:
-            targetEntity: Sylius\Component\Core\Model\Product
+            targetEntity: Sylius\Component\Product\Model\ProductInterface
             joinTable:
                 name: bitbag_cms_page_products
                 joinColumns:


### PR DESCRIPTION
Update target entity many to many to Sylius\Component\Product\Model\ProductInterface because if you dont call the interface you can not extend product in sylius